### PR TITLE
Link project website in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Adaptive Resistance Principle (ARP)
 
 This repository contains experiments, code, and notes exploring the **Adaptive Resistance Principle**. ARP describes networks of resistive elements that update their conductance in response to electrical stimuli, inspired by electrorheological fluids and self‑organising systems found in nature.
+[Project website](https://rdm3dc.github.io/ARP-RDM3DC/)
 
-[
-](https://rdm3dc.github.io/ARP-RDM3DC/)## Repository overview
+## Repository overview
 
 The project includes a variety of Python scripts and markdown documents:
 


### PR DESCRIPTION
## Summary
- Add link to the project website in README for easy navigation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fa502182c832f8cc28ef820246dbf