### PR TITLE
Add GitHub Sponsors configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: RDM3DC

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Adaptive Resistance Principle (ARP)
 
+[![Sponsor RDM3DC](https://img.shields.io/badge/Sponsor-RDM3DC-ff69b4?logo=github-sponsors)](https://github.com/sponsors/RDM3DC)
+
 This repository contains experiments, code, and notes exploring the **Adaptive Resistance Principle**. ARP describes networks of resistive elements that update their conductance in response to electrical stimuli, inspired by electrorheological fluids and self‑organising systems found in nature.
 [Project website](https://rdm3dc.github.io/ARP-RDM3DC/)
 


### PR DESCRIPTION
## Summary
- Add `.github/FUNDING.yml` to enable GitHub Sponsors for RDM3DC
- Add sponsor badge in README linking to GitHub Sponsors page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8e51857cc832f82b20d31940fd129